### PR TITLE
Add dask rl and related utility functions

### DIFF
--- a/python/clij2fft/richardson_lucy_dask.py
+++ b/python/clij2fft/richardson_lucy_dask.py
@@ -1,12 +1,153 @@
 import dask.array as da
-from clij2fft.richardson_lucy import richardson_lucy_nc 
+from clij2fft.richardson_lucy import richardson_lucy_nc, richardson_lucy
 import numpy as np
+import pyopencl as cl
+from clij2fft.pad import get_next_smooth
 
-def richardson_lucy_nc_dask(img, psf, numiterations, regularizationfactor, x_chunk_size, y_chunk_size, overlap):
+bytes_per_gb = 1024 * 1024 * 1024
+
+def gpu_mem():
+    """ get the amount of gpu memory in bytes.  Note this is the total amount of GPU memory on the device.  Not the amount of free memory. 
+
+    Returns:
+        int: GPU memory in bytes 
+    """
+    platforms = cl.get_platforms()
+
+    devices = platforms[0].get_devices()
+    mem_size = []
+    for device in devices:
+        mem_size.append(device.get_info(cl.device_info.GLOBAL_MEM_SIZE))
+    return min(mem_size)
+
+def rl_mem_footprint(img, psf, depth=(0, 0, 0)):
+    """ Gets the approximate amount of memory the RL algorithm will use for given image size, psf size and depth.
+    The depth is the amount of overlap between chunks that dask will use. The default is 0,0,0 which means no overlap.  The overlap is needed to avoid artifacts at the chunk boundaries.  
+    The depth should be at least the size of the psf.  The larger the depth the more memory is needed.  The depth should be chosen to be as small as possible to avoid artifacts.  
+    The depth is in pixels.
+
+    Note the memory use returned is approximate.  Due to internal memory use and extra padding used by the FFTs the exact memory use for OpenCL based RL is difficult to compute.  
+    Normally the RL algorithm uses 7 buffers, but this function will use a factor of 9, to allow for a factor of safety. 
+
+    Args:
+        img (numpy.ndarray): image to be deconvolved
+        psf (numpy.ndarray): point spread function
+        depth (tuple, optional): Overlap between dask chunks. Defaults to (0, 0, 0).
+
+    Returns:
+        int: memory footprint of RL
+
+    Author:
+        Dimitris Nicoloutsopoulos
+    """
+    img_size = np.array(img.shape)
+    psf_size = np.array(psf.shape)
+    depth_size = np.array(depth)
+
+    total_size = np.prod(img_size + psf_size / 2 + depth_size)
+
+    img_bytes = total_size * 4  # float32 needs 4 bytes
+    img_bytes = img_bytes * 9  # the RL deconv algo needs 9 copies
+    return np.ceil(img_bytes)
+
+def chunk_factor(img, psf, depth, mem_to_use=-1):
+    """    
+    If chunks are needed, it is desirable that the 3D image will be chunked along x and y only because
+    the psf is usually elongated along z and chunking it on z could create artifacts.
+    This function, will be chunking the image in such a manner that 4 or 16 or 32 etc
+    chunks will be used. That means that if we split x by 2 then y will also be split by 2 which
+    will result in 4 chunks with the same aspect ratio (on xy) as the original image.
+    Similarly, to get 16 chunks (if needed) we will be splitting both x and y by 4
+    
+    No check is done to determine if the image size is divisible by the chunk size.  
+    Any downstream code will need to handle this properly. 
+
+    Args:
+        img (numpy.ndarray): image to be deconvolved
+        psf (numpy.ndarray): point spread function
+        depth (tuple): Overlap between dask chunks.
+        mem_to_use (int, optional): Amount of GPU memory to use in GB.  If -1 then use all available memory.  Defaults to -1.
+
+    Returns:
+        int: chunk factor
+
+    Author:
+        Dimitris Nicoloutsopoulos
+        
+    """
+    if mem_to_use == -1:
+        gpu_bytes = gpu_mem()
+    else:
+        gpu_bytes = mem_to_use*bytes_per_gb
+    
+    img_bytes = rl_mem_footprint(img, psf, depth)
+
+    cf = 1
+    if gpu_bytes <= img_bytes:
+        # we wamt to find an integer k such that:
+        # img_bytes / 4^k <= gpu_bytes
+
+        # inflate by 1 byte so that if img_bytes==gpu_bytes then chunks will be produced.
+        img_bytes = img_bytes + 1
+
+        k = np.ceil(np.emath.logn(4, img_bytes/gpu_bytes))
+
+        # 4^k is the number of chunks.
+        # The find how much x and y must be split-by take the square root
+        cf = np.sqrt(4 ** k)
+    return cf
+
+def richardson_lucy_dask(img, psf, numiterations, regularizationfactor, non_circulant=True, overlap=10, mem_to_use=-1):
+    """ perform Richardson-Lucy using dask
+
+    Args:
+        img (numpy.ndarray): image to be deconvolved
+        psf (numpy.ndarray): point spread function
+        numiterations (int): number of iterations 
+        regularizationfactor (float): regularization factor
+        non_circulant (bool, optional): If True use non-circulant Richardson Lucy. Defaults to True.
+        overlap (int, optional): Overlap between blocks. Defaults to 10.
+        mem_to_use (int, optional): If -1 use full GPU memory, otherwise limit GPU memory to mem_to_use. Defaults to -1.
+
+    Returns:
+        numpy.ndarray: deconvolved image 
+    """
+    print('image size',img.shape)
+    print('psf size', psf.shape)
+
+    gpu_mem_ = gpu_mem()/bytes_per_gb
+    print('gpu mem is ', gpu_mem_)
+
+    rl_mem_ = rl_mem_footprint(img, psf, depth=(0, overlap, overlap))/bytes_per_gb
+    print('rl mem is ', rl_mem_)
+
+    k = chunk_factor(img, psf, depth=(0, overlap, overlap), mem_to_use=mem_to_use)
+    print('chunk factor is ', k)
+
+    if img.shape[1] % k != 0:
+        y_chunk_size = img.shape[1] // k + 1
+    else:
+        y_chunk_size = img.shape[1] // k
+
+    if img.shape[2] % k != 0:
+        x_chunk_size = img.shape[2] // k + 1
+    else:
+        x_chunk_size = img.shape[2] // k
+
+    chunk_size = (img.shape[0], y_chunk_size, x_chunk_size)
+    print('chunk size is',chunk_size)
 
     dimg = da.from_array(img,chunks=(img.shape[0], y_chunk_size, x_chunk_size))
-    out = dimg.map_overlap(richardson_lucy_nc, depth={0:0, 1:overlap, 2:overlap}, dtype=np.float32, psf=psf, numiterations=numiterations, regularizationfactor=regularizationfactor)
-    decon = out.compute(num_workers=1)
+    
+    if non_circulant:
+        rl_func = richardson_lucy_nc
+    else:
+        rl_func = richardson_lucy
 
-    return decon
+    out = dimg.map_overlap(rl_func, depth={0:0, 1:overlap, 2:overlap}, dtype=np.float32, psf=psf, numiterations=numiterations, regularizationfactor=regularizationfactor)
+    return out.compute(num_workers=1)
+
+
+
+
 

--- a/python/clij2fft/richardson_lucy_dask.py
+++ b/python/clij2fft/richardson_lucy_dask.py
@@ -23,7 +23,7 @@ def gpu_mem():
 def rl_mem_footprint(img, psf, depth=(0, 0, 0)):
     """ Gets the approximate amount of memory the RL algorithm will use for given image size, psf size and depth.
     The depth is the amount of overlap between chunks that dask will use. The default is 0,0,0 which means no overlap.  The overlap is needed to avoid artifacts at the chunk boundaries.  
-    The depth should be at least the size of the psf.  The larger the depth the more memory is needed.  The depth should be chosen to be as small as possible to avoid artifacts.  
+    The larger the depth the more memory is needed so ideally the depth should be chosen to be as small as possible while avoiding artifacts.  
     The depth is in pixels.
 
     Note the memory use returned is approximate.  Due to internal memory use and extra padding used by the FFTs the exact memory use for OpenCL based RL is difficult to compute.  
@@ -54,8 +54,8 @@ def chunk_factor(img, psf, depth, mem_to_use=-1):
     """    
     If chunks are needed, it is desirable that the 3D image will be chunked along x and y only because
     the psf is usually elongated along z and chunking it on z could create artifacts.
-    This function, will be chunking the image in such a manner that 4 or 16 or 32 etc
-    chunks will be used. That means that if we split x by 2 then y will also be split by 2 which
+    This function, will be chunking the image in such a manner that 4 or 16 or 64 etc
+    chunks will be used. That means that if we split x by 2 then y will also split y by 2 which
     will result in 4 chunks with the same aspect ratio (on xy) as the original image.
     Similarly, to get 16 chunks (if needed) we will be splitting both x and y by 4
     
@@ -84,7 +84,7 @@ def chunk_factor(img, psf, depth, mem_to_use=-1):
 
     cf = 1
     if gpu_bytes <= img_bytes:
-        # we wamt to find an integer k such that:
+        # we want to find an integer k such that:
         # img_bytes / 4^k <= gpu_bytes
 
         # inflate by 1 byte so that if img_bytes==gpu_bytes then chunks will be produced.
@@ -93,7 +93,7 @@ def chunk_factor(img, psf, depth, mem_to_use=-1):
         k = np.ceil(np.emath.logn(4, img_bytes/gpu_bytes))
 
         # 4^k is the number of chunks.
-        # The find how much x and y must be split-by take the square root
+        # Now find out how much x and y must be split-by take the square root
         cf = np.sqrt(4 ** k)
     return cf
 

--- a/python/clij2fft/test_richardson_lucy_dask.py
+++ b/python/clij2fft/test_richardson_lucy_dask.py
@@ -1,62 +1,24 @@
-import dask_image.imread
-from skimage import io
+from richardson_lucy_dask import richardson_lucy_dask
+from skimage.io import imread
 import numpy as np
-from richardson_lucy import richardson_lucy
-import matplotlib.pyplot as plt
-from clij2fft.libs import getlib
+from matplotlib import pyplot as plt
 
-# example inspired by code from https://github.com/psobolewskiPhD
-# and this forum discussion https://forum.image.sc/t/migrating-from-clij-to-pyclesperanto/54985/20
+img_name=r'D:\\images/images/Bars-G10-P15-stack-cropped.tif'
+psf_name=r'D:\\images/images/PSF-Bars-stack-cropped.tif'
 
-# define image paths (change these to local paths)
-#imgName='D:\\images/images/Bars-G10-P15-stack-cropped.tif'
-#psfName='D:\\images/images/PSF-Bars-stack-cropped.tif'
+img=imread(img_name)
+print('image shape is',img.shape)
 
-# imgName='/home/bnorthan/code/images/Bars-G10-P15-stack-cropped.tif'
-# psfName='/home/bnorthan/code/images/PSF-Bars-stack-cropped.tif'
+pad_z=50
+pad_y=291
+pad_x=700
+mem_to_use=8
 
-imgName = '/home/bnorthan/code/i2k/tnia/deconvolution-gpu-dl-course/data/deconvolution/Bars-G10-P15-stack.tif'
-psfName = '/home/bnorthan/code/i2k/tnia/deconvolution-gpu-dl-course/data/deconvolution/PSF-Bars-stack.tif'
+img = np.pad(img, [(pad_z,pad_z),(pad_y, pad_y),(pad_x, pad_x)], mode = 'constant', constant_values = 0)
+print('image shape is',img.shape)
+psf=imread(psf_name)
 
-# create a dask image
-dimage = dask_image.imread.imread(imgName)
+decon=richardson_lucy_dask(img, psf, 100, 0.0001, mem_to_use=mem_to_use)
 
-# chunk the image... the bars image likely fits into (most) GPUs memory so this
-# example is just illustrative of the API.  In a real scenario we want to make 
-# the chunk size the maximum size for which the image and temp buffers will fit in the 
-# the GPU.  (For Richardson Lucy we do calculations in 32 bit floating point and need
-# 6 copies of the image solve 6*S = GPU_Memory, and S will be the chunk size, then we (often)
-# fix z and choose x and y for S). s
-dimage_r = dimage.rechunk(chunks=(128, 128, 128)).astype(np.float32)
-
-# open the PSF, in this case don't make it a dask image
-# PSF should be much smaller than image
-psf=io.imread(psfName)
-
-# define the PSF XY half size and the XY overlap, we want the PSF half size to be smaller than the overlap
-psfHalfSize = 16
-overlap = 24
-
-# crop PSF using PSFHalfSize
-psf=psf[:,int(psf.shape[1]/2)-psfHalfSize:int(psf.shape[1]/2)+psfHalfSize-1,int(psf.shape[2]/2)-psfHalfSize:int(psf.shape[2]/2)+psfHalfSize-1]
-
-lib = getlib() 
-i=0
-
-def deconv_ocl(stack, psf=psf, iter=100, lib=lib):
-    print(stack.shape,psf.shape)
-    result = richardson_lucy(stack, psf, iter, 0, lib)
-    return result
-    #return stack
-
-out = dimage_r.map_overlap(deconv_ocl, depth={0:0, 1:overlap, 2:overlap}, boundary='reflect', dtype=np.float32)
-#out = dimage_r.map_overlap(deconv_ocl, depth={0:0, 1:0, 2:0}, boundary='reflect', dtype=np.float32)
-#out_b = dimage_r.map_blocks(deconv_ocl, dtype=np.float32)
-
-# compute with 1 worker (to avoid accessing the GPU via different threads)
-test = out.compute(num_workers=1)
-
-#max_projection = out_b.max(axis=0)
-
-plt.imshow(test.max(axis=0))
+plt.imshow(decon.max(axis=0))
 plt.show()


### PR DESCRIPTION
Add new dask scheme with using design and utility functions from Dimitris Nicoloutsopoulos.

Notes: This is a handy scheme to deconvolve a 3D image with large image plane sizes but somewhat smaller number of planes (ie sizes like 'a few thousand' in x by 'a few thousand' in y by 'a few hundred' in z, for example 2304, 2304, 300).  The scheme likely won't work if there are thousands of planes.  The implementation also only uses 1 GPU, for cases with thousands of planes and/or multiple GPUs please open an issue on clij2-fft or start a discussion on image.sc to brainstorm potential approaches.

The dask richardson lucy implementation is as follows.

1.  Detect amount of GPU memory, or (optionally) caller specifies how much GPU memory to be used.  Note it is much more difficult to detect realtime GPU memory use with opencl compared to cuda, thus we are detecting memory on the card, not memory in use, and give the caller the option of limiting memory to deal with situations where some GPU memory is used by other processes.
2.  Calculate RL memory footprint given image size, psf size, depth (overlap) size, and adding a factor of safety for potential extra memory use by the clfft library and/or memory use by concurrent GPU processes.
3.  Compute a power of 2 chunk factor (2,4,8 etc).  This will be used to subdivide in the x and y dimensions, so total blocks will be a power of 4 (4, 16, 64, etc.)
4.  Compute chunk sizes based on chunk factor then deconvolve using dask.