### PR TITLE
Fix mem leak in DeconvolveRichardsonLucyFFT.java

### DIFF
--- a/src/main/java/net/haesleinhuepf/clijx/plugins/DeconvolveRichardsonLucyFFT.java
+++ b/src/main/java/net/haesleinhuepf/clijx/plugins/DeconvolveRichardsonLucyFFT.java
@@ -299,6 +299,8 @@ public class DeconvolveRichardsonLucyFFT extends AbstractCLIJ2Plugin implements
 		
 		// the normalization factor is the correlation between valid region and psf 
 		ConvolveFFT.runConvolve2(clij2, gpuvalidregion, psf, gpunormal, true);
+
+		gpuvalidregion.close();
 		
 		return gpunormal;
 	}


### PR DESCRIPTION
See discussion in https://forum.image.sc/t/clij2-imglib2-cache-tiled-deconvolution/92331/7

With this modification, the only remaining buffer at the end of the deconvolution (in InteractiveImgLib2CacheDeconvolve) is the PSF buffer, which is typically very small.